### PR TITLE
Fix: fix compiling error

### DIFF
--- a/exe/src/instructions.rs
+++ b/exe/src/instructions.rs
@@ -208,7 +208,7 @@ pub fn build_trampoline(
 
     let mut instructions = stolen_bytes.instrs.clone();
 
-    for mut i in instructions {
+    for i in &mut instructions {
         if i.code() == Code::Int3 {
             i.set_code(Code::Nop_rm16);
         }


### PR DESCRIPTION
## Environment
```
$cargo --version
cargo 1.91.0-nightly (71eb84f21 2025-08-17)

$rustc --version
rustc 1.91.0-nightly (040a98af7 2025-08-20)
```

## Issue
Compiling error, shown as

```
$cargo check

error[E0382]: borrow of moved value: `instructions`
   --> exe\src\instructions.rs:222:5
    |
209 |     let mut instructions = stolen_bytes.instrs.clone();
    |         ---------------- move occurs because `instructions` has type `Vec<Instruction>`, which does not implement the `Copy` trait
210 |
211 |     for mut i in instructions {
    |                  ------------ `instructions` moved due to this implicit call to `.into_iter()`
...
222 |     instructions.push(
    |     ^^^^^^^^^^^^ value borrowed here after move
    |
note: `into_iter` takes ownership of the receiver `self`, which moves `instructions`
```

## Fix

Fixed as in this pr.